### PR TITLE
Mark factory methods as static to preven warnings.

### DIFF
--- a/Text/Wiki.php
+++ b/Text/Wiki.php
@@ -456,7 +456,7 @@ class Text_Wiki
     *    in further calls it will be effectively ignored.
     * @return &object a reference to the Text_Wiki unique instantiation.
     */
-    public function &singleton($parser = 'Default', $rules = null)
+    public static function &singleton($parser = 'Default', $rules = null)
     {
         static $only = array();
         if (!isset($only[$parser])) {

--- a/Text/Wiki.php
+++ b/Text/Wiki.php
@@ -480,7 +480,7 @@ class Text_Wiki
      *    {@see Text_Wiki::singleton} for a list of rules
      * @return Text_Wiki a Parser object extended from Text_Wiki
      */
-    public function factory($parser = 'Default', $rules = null)
+    public static function factory($parser = 'Default', $rules = null)
     {
         $class = 'Text_Wiki_' . $parser;
         $file = str_replace('_', '/', $class).'.php';


### PR DESCRIPTION
"In PHP 7, calling non-static methods statically is deprecated, and will generate an E_DEPRECATED warning."